### PR TITLE
Fix segfault for malformed link/image titles

### DIFF
--- a/smu.c
+++ b/smu.c
@@ -324,7 +324,7 @@ dolink(const char *begin, const char *end, int newblock) {
 		/* strip trailing whitespace */
 		for (linkend = p; linkend > link && isspace(*(linkend - 1)); linkend--);
 		for (titleend = q - 1; titleend > link && isspace(*(titleend)); titleend--);
-		if (*titleend != sep) {
+		if (titleend < title || *titleend != sep) {
 			return 0;
 		}
 	}


### PR DESCRIPTION
Before, `echo '![a](b ")' | ./smu` caused a segfault. The syntax is not
valid, since the title is missing the terminating quote. So returning
```
<p>![a](b ")</p>
```
in this case seems to be right.