### PR TITLE
MathJax support and bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,16 @@ options:
 
 .c.o:
 	@echo CC $<
-	@${CC} -c ${CFLAGS} $<
+	@${CC} -c ${CPPFLAGS} ${CFLAGS} $<
 
 ${OBJ}: config.mk
 
 smu: ${OBJ}
 	@echo LD $@
 	@${CC} -o $@ ${OBJ} ${LDFLAGS}
+
+math: CPPFLAGS += -DDISPLAY_MATH_DELIMITER='$$$$' -DINLINE_MATH_DELIMITER='$$'
+math: options smu
 
 clean:
 	@echo cleaning

--- a/README
+++ b/README
@@ -248,6 +248,8 @@ Other interesting stuff
   	But here is  
   	one.
 
+* Text wrapped in `$` or `$$` is not processed so it can be used with MathJax
+
 embed HTML
 ----------
 

--- a/README
+++ b/README
@@ -248,7 +248,8 @@ Other interesting stuff
   	But here is  
   	one.
 
-* Text wrapped in `$` or `$$` is not processed so it can be used with MathJax
+* If built with `make math`, text wrapped in `$` or `$$` is not processed
+  so it can be used with MathJax
 
 embed HTML
 ----------

--- a/smu.c
+++ b/smu.c
@@ -70,6 +70,8 @@ static Tag surround[] = {
 	{ "```",        0,      "<code>",       "</code>" },
 	{ "``",         0,      "<code>",       "</code>" },
 	{ "`",          0,      "<code>",       "</code>" },
+	{ "$$",         0,      "$$",           "$$" },
+	{ "$",          0,      "$",            "$" },
 	{ "___",        1,      "<strong><em>", "</em></strong>" },
 	{ "***",        1,      "<strong><em>", "</em></strong>" },
 	{ "__",         1,      "<strong>",     "</strong>" },
@@ -655,8 +657,13 @@ dosurround(const char *begin, const char *end, int newblock) {
 		} while (p && p[-1] == '\\');
 		if (p && p[-1] != '\\')
 			stop = p;
-		if (!stop || stop < start || stop >= end)
+		if (!stop || stop <= start || stop >= end)
 			continue;
+		if (stop[0] == '$' && l == 1) {
+			/* not inline math if span starts or ends with space or contains newline */
+			if (isspace(start[0]) || isspace(stop[-1]) || strchr(start, '\n') < stop)
+				continue;
+		}
 		fputs(surround[i].before, stdout);
 
 		/* Single space at start and end are ignored */


### PR DESCRIPTION
This prevents processing of text inside `$` and `$$` so that MathJax will work. Without this, for example, a math formula with underscores would get broken by `<em>` insertions.

For single dollar signs, since documents often contain single dollar signs for other reasons, we only change the behavior if the span does not start or end with whitespace and does not contain a newline. In the unlikely event that a document unintentionally matches this pattern, it is even more unlikely that it will cause a real problem because it just prevents processing but doesn't make any changes. Dollar signs inside code blocks will not be affected.

This also fixes a bug that caused "surround" characters to generate tags even when the start and stop tokens were at the same location.