### PR TITLE
fix: unescape &lt; so < shows as a symbol, not text.

### DIFF
--- a/smu.c
+++ b/smu.c
@@ -115,8 +115,8 @@ static const char *replace[][2] = {
 	{ "\\|",        "|" },
 	{ "\\~",        "~" },
 	/* HTML syntax symbols that need to be turned into entities */
-	{ "<",          "&lt;" },
-	{ ">",          "&gt;" },
+	{ "<",          "<" },
+	{ ">",          ">" },
 	{ "&amp;",      "&amp;" },  /* Avoid replacing the & in &amp; */
 	{ "&",          "&amp;" },
 	/* Preserve newlines with two spaces before linebreak */


### PR DESCRIPTION
if the user wants to use < they just need to type `\\<`
if he type < directly it will be convert to a normal < in the output